### PR TITLE
Fix: subtotal value returning NaN when a line item value is not a number

### DIFF
--- a/src/views/ReceiptView.vue
+++ b/src/views/ReceiptView.vue
@@ -108,8 +108,8 @@ export default {
       });
     },
     subtotal() {
-      let selectedItems = this.selectedItems.filter((item) => typeof item === "number");
-      let subtotal = selectedItems.reduce((acc, item) => {
+      let validSelectedItems = this.selectedItems.filter((item) => typeof item.amount === "number")
+      let subtotal = validSelectedItems.reduce((acc, item) => {
         return acc + item.amount;
       }, 0);
       return `${ this.receipt.currency} ${ subtotal.toFixed(2) }`;

--- a/src/views/ReceiptView.vue
+++ b/src/views/ReceiptView.vue
@@ -108,7 +108,8 @@ export default {
       });
     },
     subtotal() {
-      let subtotal = this.selectedItems.reduce((acc, item) => {
+      let selectedItems = this.selectedItems.filter((item) => typeof item === "number");
+      let subtotal = selectedItems.reduce((acc, item) => {
         return acc + item.amount;
       }, 0);
       return `${ this.receipt.currency} ${ subtotal.toFixed(2) }`;


### PR DESCRIPTION
## Objective
- Fix subtotal value returning `NaN` when the value of a line item is not a number


https://github.com/helloworld-ng/dotch/assets/48217306/3d1e57dc-29e8-441b-aa6b-c9894a4610f0


## Description of Change
- Added a filter to get only number values from the `this.selectedItems` array before running the `reduce` method on the items

## Quality Assurance
- Assert that the `subtotal` doesn't return `NaN` when the value of a line item is not available